### PR TITLE
Fallback listen address to public address

### DIFF
--- a/bin/detect_ips.sh
+++ b/bin/detect_ips.sh
@@ -40,5 +40,9 @@ while read lhs rhs; do
 done < <(/sbin/ifconfig)
 
 echo "KADCAST_PUBLIC_ADDRESS=$PUBLIC_IP:9000"
-echo "KADCAST_LISTEN_ADDRESS=$myIp:9000"
+if [ -z "$myIp" ]; then
+    echo "KADCAST_LISTEN_ADDRESS=$PUBLIC_IP:9000"
+else
+    echo "KADCAST_LISTEN_ADDRESS=$myIp:9000"
+fi
 


### PR DESCRIPTION
Updated lines in the script so it uses the $PUBLIC_IP as listen address for Kadcast when $myIp is null. (due to issues on Hetzner cloud instances)
Investigated and resolved by @herr-seppia and @justmvg