### PR TITLE
Consensus pwd setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ mv /root/.dusk/rusk-wallet/5YgmFvL5WKVbff9LtNwaY5VU17w93CXEs9ujPVRnEkcDko6Fsiv9m
 
 Run the following command and it will prompt you to enter the password for the consensus keys file:
 ```sh
-read -p "Consensus keys password:" ckp && echo "DUSK_CONSENSUS_KEYS_PASS=$ckp" > /opt/dusk/services/dusk.conf
+/opt/dusk/bin/setup_consensus_pwd.sh
 ```
 
 ### Start services

--- a/bin/setup_consensus_pwd.sh
+++ b/bin/setup_consensus_pwd.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "Consensus keys password: "
+read ckp
+echo "DUSK_CONSENSUS_KEYS_PASS=$ckp" > /opt/dusk/services/dusk.conf

--- a/itn-installer.sh
+++ b/itn-installer.sh
@@ -45,8 +45,7 @@ mv -n /opt/dusk/installer/conf/* /opt/dusk/conf/
 # Don't overwrite previous services conf
 mv -n /opt/dusk/installer/services/* /opt/dusk/services/
 
-chmod +x /opt/dusk/bin/detect_ips.sh
-chmod +x /opt/dusk/bin/check_consensuskeys.sh
+chmod +x /opt/dusk/bin/*
 
 mkdir -p /opt/dusk/data/.rusk
 mkdir -p /opt/dusk/data/chain
@@ -86,8 +85,8 @@ ufw allow 9000:9005/udp
 echo "Dusk node installed"
 echo "-----"
 echo "Prerequisites for launching:"
-echo "1. Provide CONSENSUS_KEYS file"
-echo "2. Set DUSK_CONSENSUS_KEYS_PASS"
+echo "1. Provide CONSENSUS_KEYS file (default in /opt/dusk/conf/consensus.keys)"
+echo "2. Set DUSK_CONSENSUS_KEYS_PASS (use /opt/dusk/bin/setup_consensus_pwd.sh)"
 echo
 echo "-----"
 echo "To launch the node: "


### PR DESCRIPTION
Improve consensus password handling

- Prevent passwords ending up in history logs (by @justmvg)
- Add `setup_consensus_pwd.sh` utility
- Update README.md
- Add password setup instruction to the installer output