### PR TITLE
Request to add checker for dig (dnsutils)

### DIFF
--- a/itn-installer.sh
+++ b/itn-installer.sh
@@ -21,6 +21,7 @@ check_installed curl curl
 check_installed jq jq
 check_installed route net-tools
 check_installed logrotate logrotate
+check_installed dig dnsutils
 
 echo "Creating rusk service user"
 id -u dusk >/dev/null 2>&1 || useradd -r dusk


### PR DESCRIPTION
Probably a problem because of which many people in the chat can't start `rusk.service`. Ubuntu 22.04 does not have the `dnsutils` toolkit by default.