### PR TITLE
Enhance state downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,12 @@ service rusk status
 
 ## Fast Syncing with Archival State Download
 
-To significantly reduce the time required to sync your node, you can use the `/opt/dusk/bin/download_state` command. This command stops your node and replaces its current state with the latest published state from one of Dusk's archival nodes. 
+To significantly reduce the time required to sync your node to the latest published state, you can use the `download_state` command. This command stops your node and replaces its current state with the latest published state from one of Dusk's archival nodes. 
+
+To see the available published states, run:
+```sh
+download_state --list
+```
 
 ### Using the Fast Sync Command
 

--- a/bin/download_state.sh
+++ b/bin/download_state.sh
@@ -21,8 +21,9 @@ display_warning() {
   esac
 }
 
+# Function to display all published states
 list_states() {
-  echo "Available states:"
+  echo "Available published states:"
   for state in "${AVAILABLE_STATES[@]}"; do
     echo "- $state"
   done
@@ -34,14 +35,12 @@ if [ $# -eq 0 ]; then
   # No argument provided, use the latest state
   state_number=$LATEST_STATE
 elif [ "$1" = "--list" ]; then
-  # User requested to list all possible states
   list_states
 else
-  # User provided a specific state
+  # User requests a specific state
   state_number=$1
   if ! [[ " ${AVAILABLE_STATES[*]} " =~ " ${state_number} " ]]; then
     echo "Error: State $state_number is not available."
-    echo "The following states are available:"
     list_states
     exit 1
   fi

--- a/bin/download_state.sh
+++ b/bin/download_state.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+AVAILABLE_STATES=(409123 408251 407159 404345 379502)
+LATEST_STATE=${AVAILABLE_STATES[0]}
+
 # Function to display a warning message
 display_warning() {
   echo "WARNING: This operation will STOP your node and REPLACE the current state with a new one."
@@ -18,11 +21,30 @@ display_warning() {
   esac
 }
 
+list_states() {
+  echo "Available states:"
+  for state in "${AVAILABLE_STATES[@]}"; do
+    echo "- $state"
+  done
+  exit 0
+}
+
 # Check if an argument is provided, otherwise use the fallback value (348211)
 if [ $# -eq 0 ]; then
-  state_number=348211
+  # No argument provided, use the latest state
+  state_number=$LATEST_STATE
+elif [ "$1" = "--list" ]; then
+  # User requested to list all possible states
+  list_states
 else
+  # User provided a specific state
   state_number=$1
+  if ! [[ " ${AVAILABLE_STATES[*]} " =~ " ${state_number} " ]]; then
+    echo "Error: State $state_number is not available."
+    echo "The following states are available:"
+    list_states
+    exit 1
+  fi
 fi
 
 # Display warning and get user confirmation
@@ -31,7 +53,6 @@ display_warning
 # Download the file
 STATE_URL="https://nodes.dusk.network/state/$state_number"
 echo "Downloading state $state_number from $STATE_URL..."
-
 
 if ! curl -f -so  /tmp/state.tar.gz -L "$STATE_URL"; then
   echo "Error: Download failed. Exiting."

--- a/bin/download_state.sh
+++ b/bin/download_state.sh
@@ -26,19 +26,22 @@ list_states() {
     echo "Error: Failed to fetch the list of states."
     exit 1
   fi
-  exit 0
 }
 
 # Function to check if a specific state exists
 state_exists() {
   local state=$1
-  if curl -f -L -s "$STATE_LIST_URL" | grep -q "^$state$"; then
-    return 0 # State exists
-  else
-    echo "State does not exist"
-    list_states
-    return 1 # State does not exist
-  fi
+  while : ; do
+    if curl -f -L -s "$STATE_LIST_URL" | grep -q "^$state$"; then
+      return 0 # State exists
+    else
+      echo "State does not exist. Please enter a state from the list below:"
+      list_states
+      read -p "Enter a valid state number: " state
+      # Update the state_number variable in the global scope
+      state_number=$state
+    fi
+  done
 }
 
 # Function to get the latest state
@@ -50,10 +53,10 @@ get_latest_state() {
 if [ "$1" = "--list" ]; then
   # List all possible states
   list_states
+  exit 0
 elif [ -n "$1" ]; then
   # User provided a specific state, check if it exists
   state_exists "$1"
-  state_number=$1
 else
   # No argument provided, use the latest state
   state_number=$(get_latest_state)

--- a/itn-installer.sh
+++ b/itn-installer.sh
@@ -59,6 +59,7 @@ mv -f /opt/dusk/conf/wallet.toml /root/.dusk/rusk-wallet/config.toml
 chmod +x /opt/dusk/bin/*
 ln -sf /opt/dusk/bin/rusk /usr/bin/rusk
 ln -sf /opt/dusk/bin/ruskquery /usr/bin/ruskquery
+ln -sf /opt/dusk/bin/download_state /usr/bin/download_state
 ln -sf /opt/dusk/bin/rusk-wallet /usr/bin/rusk-wallet
 
 echo "Downloading verifier keys"


### PR DESCRIPTION
- Provide a list of available published states, with the latest being the first entry
- Add a `--list` command to `download_state`
- On providing a wrong published state, return a list of available states
- Make `download_state` available as a bin command to users
- Update README with new commands