### PR TITLE
Fix download_state symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ download_state --list
 
 2. Execute the fast sync command.
    ```sh
-   sudo /opt/dusk/bin/download_state.sh 
+   download_state
    ```
    
    If you want to sync up with a specific state instead of the default one, you need to pass the block height of the state you want to syncup with.
    ```sh
-   sudo /opt/dusk/bin/download_state.sh 369876
+   download_state 369876
    ```
 
    Follow the prompts to confirm the operation.

--- a/itn-installer.sh
+++ b/itn-installer.sh
@@ -59,7 +59,7 @@ mv -f /opt/dusk/conf/wallet.toml /root/.dusk/rusk-wallet/config.toml
 chmod +x /opt/dusk/bin/*
 ln -sf /opt/dusk/bin/rusk /usr/bin/rusk
 ln -sf /opt/dusk/bin/ruskquery /usr/bin/ruskquery
-ln -sf /opt/dusk/bin/download_state /usr/bin/download_state
+ln -sf /opt/dusk/bin/download_state.sh /usr/bin/download_state
 ln -sf /opt/dusk/bin/rusk-wallet /usr/bin/rusk-wallet
 
 echo "Downloading verifier keys"


### PR DESCRIPTION
Alternatively, we can rename `download_state.sh` to `download_state`.