### PR TITLE
Update download_state.sh

### DIFF
--- a/bin/download_state.sh
+++ b/bin/download_state.sh
@@ -9,7 +9,7 @@ display_warning() {
   read -p "Are you sure you want to proceed? (Y/n): " choice
 
   case "$choice" in
-    Y )
+    [yY] )
       return 0  # User confirmed, proceed
       ;;
     * )


### PR DESCRIPTION
When we want to download bloks from state with using `download_state` command, it asks us "**Are you sure you want to proceed? (Y/n)**" and if we give "y" as input, the operation is aborted immediately. I changed the `display_warning()` function in `bin/download_state.sh` file to be able to accept both "y" and "Y".

![image](https://github.com/dusk-network/itn-installer/assets/44838743/64db62de-3ee8-416b-90b7-29d225e4d102)
